### PR TITLE
Add nginx-ingress controller and migrate away from minikube addon

### DIFF
--- a/crossplane-resources/core/ingress-nginx.yml
+++ b/crossplane-resources/core/ingress-nginx.yml
@@ -1,0 +1,20 @@
+apiVersion: helm.crossplane.io/v1beta1
+kind: Release
+metadata:
+  name: ingress-nginx
+spec:
+  forProvider:
+    chart:
+      name: ingress-nginx
+      repository: https://kubernetes.github.io/ingress-nginx
+      version: "4.12.0"
+    namespace: ingress-nginx
+    skipCreateNamespace: false
+    values:
+      controller:
+        service:
+          type: LoadBalancer
+    wait: true
+    waitTimeout: 600s
+  providerConfigRef:
+    name: helm-provider


### PR DESCRIPTION
- Manage nginx-ingress with crossplane and not the minikube addon